### PR TITLE
UPDATE createDslContainers to use jenkins slave

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This repo contains a Jenkins shared library, referred to as the contraDSL, which
 
 ### OpenShift Configuration
 #### Container Templates
-The contraDSL makes use of three containers, ```linchpin-executor```,  ```ansible-executor```, and ```jnlp```. These containers must exist within OpenShift and can be added by performing the following steps:
+The contraDSL makes use of three containers, ```linchpin-executor```,  ```ansible-executor```, and ```jenkins-contra-slave```. These containers must exist within OpenShift and can be added by performing the following steps:
 * Checkout the contra-hdsl repo, if you haven't already: ```$ git clone https://github.com/openshift/contra-hdsl.git```
 * Login to your OpenShift instance: ```$ oc login```
 * Select your project namespace: ```$ oc project <your project namespace>```

--- a/README.md
+++ b/README.md
@@ -15,13 +15,24 @@ This repo contains a Jenkins shared library, referred to as the contraDSL, which
 
 ### OpenShift Configuration
 #### Container Templates
-The contraDSL makes use of two containers, ```linchpin-executor``` and ```ansible-executor```. These containers must exist within OpenShift and can be added by performing the following steps:
+The contraDSL makes use of three containers, ```linchpin-executor```,  ```ansible-executor```, and ```jnlp```. These containers must exist within OpenShift and can be added by performing the following steps:
 * Checkout the contra-hdsl repo, if you haven't already: ```$ git clone https://github.com/openshift/contra-hdsl.git```
 * Login to your OpenShift instance: ```$ oc login```
 * Select your project namespace: ```$ oc project <your project namespace>```
 * Change to the root of the contra-hdsl repo: ```$ cd /path/to/contra-hdsl```
 * Add the ```linchpin-executor``` buildconfig template: ```$ oc create -f config/s2i/linchpin/linchpin-buildconfig-template.yaml```
 * Add the ```ansible-executor``` buildconfig template: ```$ oc create -f config/s2i/ansible/ansible-buildconfig-template.yaml```
+* Add the ```jenkins-contra-slave``` buildconfig template: ```$ oc create -f config/s2i/jslave/jslave-buildconfig-template.yaml```
+
+The HDSL expects that these containers should be tagged as "stable" by default, although this can be overridden.
+
+To tag these containers as "stable":
+
+```$ oc tag <project namespace>/ansible-executor:latest <project namespace>/ansible-executor:stable```
+
+```$ oc tag <project namespace>/linchpin-executor:latest <project namespace>/linchpin-executor:stable```
+
+```$ oc tag <project namespace>/jenkins-contra-slave:latest <project namespace>/jenkins-contra-slave:stable```
 
 #### Secret Configuration
 The buildconfig template for the ```linchpin-executor``` container needs to access the contra-hdsl repository and as such needs to use SSH key authentication. 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,6 @@ To tag these containers as "stable":
 ```$ oc tag <project namespace>/linchpin-executor:latest <project namespace>/linchpin-executor:stable```
 
 ```$ oc tag <project namespace>/jenkins-contra-slave:latest <project namespace>/jenkins-contra-slave:stable```
-
-#### Secret Configuration
-The buildconfig template for the ```linchpin-executor``` container needs to access the contra-hdsl repository and as such needs to use SSH key authentication. 
-
-The template is configured to use a source secret named ```contra-hdsl-deploy-key``` which should be an SSH key which has permissions to pull from the contra-hdsl repository.
   
 ### Global Library Configuration
 The contraDSL needs to be configured on the Jenkins master. The necessary steps are below.

--- a/vars/createDslContainers.groovy
+++ b/vars/createDslContainers.groovy
@@ -22,7 +22,6 @@ def call(Map<String, ?> config=[:], Closure body){
     String jenkinsContraSlaveTag = config.jenkinsContraSlaveTag ?: 'stable'
     String linchpinContainerName = config.linchpinContainerName ?: 'linchpin-executor'
     String ansibleContainerName = config.ansibleContainerName ?: 'ansible-executor'
-    String slaveContainerName = config.slaveContainerName ?: 'jenkins-contra-slave'
 
 
     podTemplate(name: podName,
@@ -33,7 +32,7 @@ def call(Map<String, ?> config=[:], Closure body){
             namespace: openshiftNamespace,
             containers:[
                     // This adds the custom slave container to the pod. Must be first with name 'jnlp'
-                    containerTemplate(name: slaveContainerName,
+                    containerTemplate(name: 'jnlp',
                             image: "${dockerRepoURL}/${openshiftNamespace}/jenkins-contra-slave:${jenkinsContraSlaveTag}",
                             ttyEnabled: false,
                             args: '${computer.jnlpmac} ${computer.name}',

--- a/vars/createDslContainers.groovy
+++ b/vars/createDslContainers.groovy
@@ -19,8 +19,10 @@ def call(Map<String, ?> config=[:], Closure body){
     String dockerRepoURL = config.dockerRepoURL ?: '172.30.1.1:5000'
     String ansibleExecutorTag = config.ansibleExecutorTag ?: 'stable'
     String linchpinExecutorTag = config.linchpinExecutorTag ?: 'stable'
+    String jenkinsContraSlaveTag = config.jenkinsContraSlaveTag ?: 'stable'
     String linchpinContainerName = config.linchpinContainerName ?: 'linchpin-executor'
     String ansibleContainerName = config.ansibleContainerName ?: 'ansible-executor'
+    String slaveContainerName = config.slaveContainerName ?: 'jenkins-contra-slave'
 
 
     podTemplate(name: podName,
@@ -31,8 +33,8 @@ def call(Map<String, ?> config=[:], Closure body){
             namespace: openshiftNamespace,
             containers:[
                     // This adds the custom slave container to the pod. Must be first with name 'jnlp'
-                    containerTemplate(name: 'jnlp',
-                            image: "${dockerRepoURL}/${openshiftNamespace}/jenkins-contra-slave:stable",
+                    containerTemplate(name: slaveContainerName,
+                            image: "${dockerRepoURL}/${openshiftNamespace}/jenkins-contra-slave:${jenkinsContraSlaveTag}",
                             ttyEnabled: false,
                             args: '${computer.jnlpmac} ${computer.name}',
                             command: '',


### PR DESCRIPTION
Updated createDslContainers to reference the newly added jenkins slave
template. Also updated the documentation to include instructions on how
to add this new template as well as including previously missing
instructions on how to tag the required builds with a ```stable``` tag.