### PR TITLE
ADD report HDSL method

### DIFF
--- a/vars/report.groovy
+++ b/vars/report.groovy
@@ -28,16 +28,16 @@ Thank you,
 Contra Productization Automation"""
 
         HashMap<String, ?> mailValues=[
-                to: config.recipientEmail,
+                to: recipientEmails,
                 from: config.fromEmail ?: 'ContraProductizationAutomation',
                 replyTo: config.replyTo ?: 'noreply@redhat.com',
                 subject: subject,
                 body: body
         ]
 
-        if (config.ccEmail){ mailValues.ccEmail = config.ccEmail }
+        if (ccEmails){ mailValues.ccEmail = ccEmails}
 
-        if (config.bccEmail){ mailValues.bccEmail = config.bccEmail }
+        if (bccEmails){ mailValues.bccEmail = bccEmails }
 
         mail(mailValues)
     }

--- a/vars/report.groovy
+++ b/vars/report.groovy
@@ -21,7 +21,7 @@ def call(Map<String, ?> config = [:]) {
 
 Job Name: ${env.JOB_NAME}
 Job Build #: ${env.BUILD_NUMBER}
-Jobs result: ${currentBuild.currentResult}
+Job result: ${currentBuild.currentResult}
 Job URL: <a href="${BUILD_URL}">${BUILD_URL}</a>
 
 Thank you,

--- a/vars/report.groovy
+++ b/vars/report.groovy
@@ -1,0 +1,56 @@
+def call(Map<String, ?> config = [:]) {
+    String reportingType = config.reportingType ?: 'email'
+
+    Map<String, String> configData = readJSON text: env.configJSON
+
+    if (reportingType == 'email'){
+        ArrayList recipientEmails = []
+        ArrayList ccEmails = []
+        ArrayList bccEmails = []
+
+        if ( configData.recipientEmail ) { combineEmailAddresses(recipientEmails, configData.recepientEmail) }
+        if ( config.recipientEmail ){ combineEmailAddresses(recipientEmails, config.recipientEmail) }
+        if ( configData.ccEmail ) { combineEmailAddresses(ccEmails, configData.ccEmail) }
+        if ( config.ccEmail ){ combineEmailAddresses(ccEmails, config.ccEmail) }
+        if ( configData.bccEmail ) { combineEmailAddresses(bccEmails, configData.bccEmail) }
+        if ( config.bccEmail ){ combineEmailAddresses(bccEmails, config.bccEmail) }
+
+        // subject: JOB NAME - BUILD - RESULT
+        String subject = "${env.JOB_NAME} - ${env.BUILD_NUMBER} - ${currentBuild.currentResult}"
+        String body = """Hi, here's some info about your job!
+
+Job Name: ${env.JOB_NAME}
+Job Build #: ${env.BUILD_NUMBER}
+Jobs result: ${currentBuild.currentResult}
+Job URL: <a href="${BUILD_URL}">${BUILD_URL}</a>
+
+Thank you,
+Contra Productization Automation"""
+
+        HashMap<String, ?> mailValues=[
+                to: config.recipientEmail,
+                from: config.fromEmail ?: 'ContraProductizationAutomation',
+                replyTo: config.replyTo ?: 'noreply@redhat.com',
+                subject: subject,
+                body: body
+        ]
+
+        if (config.ccEmail){ mailValues.ccEmail = config.ccEmail }
+
+        if (config.bccEmail){ mailValues.bccEmail = config.bccEmail }
+
+        mail(mailValues)
+    }
+}
+
+static combineEmailAddresses(ArrayList addresses, Object entry) {
+    if (entry instanceof String) {
+        addresses.add(entry)
+        return addresses
+    }
+
+    if (entry instanceof ArrayList){
+        addresses.addAll(entry)
+        return addresses
+    }
+}

--- a/vars/report.txt
+++ b/vars/report.txt
@@ -1,0 +1,19 @@
+<p>The report variable handles reporting test results and other data.</p>
+
+<h1 id="examples">Examples:</h1>
+
+<h2 id="defaultUsage">Using the default invocation:</h2>
+
+<pre><code>report()</code></pre>
+
+<p>This usage assumes the presence of a <code>contra.yml</code> file in the root of <code>WORKSPACE</code> for the Jenkins job.</p>
+
+<h2 id="passingarbitraryconfigurationparameters">Passing arbitrary configuration parameters:</h2>
+
+<pre><code>report recipientEmail: ['carol@example.com', 'susan@example.com'],
+               ccEmail: ['bob@example.com', 'kim@example.com'],
+               bccEmail: 'carl@example.org',
+               replyTo: 'bot@example.com'
+</code></pre>
+
+<p>This usage allows for the passing of a specific configuration parameters. The optional parameters above can be used independently of one another</p>


### PR DESCRIPTION
Adding report() method to the HDSL. Currently it provides a single
reporting type, which is email. Recipient email addresses, cc email
addresses, bcc addresses can be supplied via contra.yml or when calling
the report method.