### PR TITLE
FIX typo in name for jenkins-contra-slave-builder

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The contraDSL makes use of three containers, ```linchpin-executor```,  ```ansibl
 The contraDSL requires that the necessary container imagestreams exist.
 * Deploy the ```linchpin-executor``` imagestream: ```$ oc new-app linchpin-executor```
 * Create the ```ansible-executor``` imagestream: ```$ oc new-app ansible-executor```
-* Create the ```jenkins-contra-slave``` imagestream: ```$ oc new-app jenkins-contra-slave-buider```
+* Create the ```jenkins-contra-slave``` imagestream: ```$ oc new-app jenkins-contra-slave-builder```
 
 
 #### Tag Container Imagestreams


### PR DESCRIPTION
Fixed a typo in the instruction to create the container imagestream for
the Jenkins Slave container.