### PR TITLE
Update to newer ansible-executor container build

### DIFF
--- a/config/s2i/ansible/ansible-buildconfig-template.yaml
+++ b/config/s2i/ansible/ansible-buildconfig-template.yaml
@@ -27,7 +27,7 @@ objects:
     - type: ConfigChange
     source:
       type: DockerFile
-      dockerfile: "FROM contrainfra/ansible-executor:v1.1.0"
+      dockerfile: "FROM contrainfra/ansible-executor:v1.1.2"
     strategy:
       dockerStrategy:
         env:


### PR DESCRIPTION
This version includes python2-virtualenv which allows for local
pip installs even though the container isn't running as root.

Handy for installing deps needed for unit tests.