### PR TITLE
add timeout

### DIFF
--- a/src/org/centos/contra/Infra/Defaults.groovy
+++ b/src/org/centos/contra/Infra/Defaults.groovy
@@ -38,5 +38,5 @@ class Defaults {
     public static final String jnlpContainerName = 'jnlp'
     public static final String linchpinContainerName = 'linchpin-executor'
 
-
-}
+    // The default timeout in MINUTES
+    public static final int executionTimeout = 30


### PR DESCRIPTION
The overall execution should be limited by a timeout. In certain cases like an infra failure, the hdsl pod is not entering a readiness state, the build hangs.
During the work on ember-csi project we faced such a use case.

@ifireball please review