### PR TITLE
Parallelism

### DIFF
--- a/docs/source/withHdslPod.rst
+++ b/docs/source/withHdslPod.rst
@@ -34,14 +34,14 @@ Parameters
    ========================= ====== ======== =======
    openshift_service_account String False    | OpenShift service account to use.
                                              | **Default**: ``'jenkins'``
-   linchpin_container_name   String False    | Name of the linchpin container
+   linchpinContainerName     String False    | Name of the linchpin container
                                              | **Default**: ``'linchpin-executor'``
    linchpin_image_name       String False    | Image to use
                                              | **Default**: ``'linchpin-executor'``
    linchpin_tag              String False    Tag to use
-   ansible_container_name    String False    | Name of the ansible-exeuctor container
+   ansibleContainerName      String False    | Name of the ansible-executor container
                                              | **Default**: ``'ansible-executor'``
-   ansible_container_name    String False    | Image to use
+   ansible_image_name        String False    | Image to use
                                              | **Default**: ``'ansible-executor'``
    ansible_tag               String False    Tag to use
    jnlp_image_name           String False    | Image to use for the jnlp node
@@ -65,9 +65,9 @@ Overriding the ansible and/or linchpin container name(s)
 It is possible to specify an alternate image by providing a name and / or tag of a different container for the
 linchpin-executor, ansible-executor, or jnlp slave. ::
 
-    withHdslPod ansible_container_name: 'my-ansible-container',
+    withHdslPod ansibleContainerName: 'my-ansible-container',
                 ansible_executor_tag: 'latest'
-                linchpin_container_name: 'my-linchpin-container',
+                linchpinContainerName: 'my-linchpin-container',
     {
         // Jenksinfile content goes here
     }

--- a/resources/org/centos/contra/Infra/topologyTemplates/beaker.template
+++ b/resources/org/centos/contra/Infra/topologyTemplates/beaker.template
@@ -5,7 +5,7 @@ ${index}_${providerType}:
       - resource_group_name: "beaker-slaves"
         resource_group_type: "beaker"
         resource_definitions:
-          - role: "bkr_server"<% if ( jobGroup ) "\n        job_group: \"${jobGroup}\"" %>
+          - role: "bkr_server"<% if ( jobGroup ) out.print "\n            job_group: \"${jobGroup}\"" %>
             whiteboard: "${whiteboard ? whiteboard : 'Dynamically provisioned'}"
             recipesets:
               - name: "${name}"

--- a/src/org/centos/contra/Infra/Defaults.groovy
+++ b/src/org/centos/contra/Infra/Defaults.groovy
@@ -38,6 +38,11 @@ class Defaults {
     public static final String jnlpContainerName = 'jnlp'
     public static final String linchpinContainerName = 'linchpin-executor'
 
+    // The default names for secret files stored in Jenkins
+    public static final String AWS_CREDS_ID = 'aws.creds'
+    public static final String BEAKER_CREDS_ID = 'beaker.creds'
+    public static final String OPENSTACK_CREDS_ID = 'openstack.creds'
+
     // The default timeout in MINUTES
     public static final int executionTimeout = 30
     public static final String executionTimeoutUnit = 'MINUTES'

--- a/src/org/centos/contra/Infra/Providers/Aws.groovy
+++ b/src/org/centos/contra/Infra/Providers/Aws.groovy
@@ -1,22 +1,17 @@
 package org.centos.contra.Infra.Providers
 
-class Aws implements Serializable{
+class Aws extends Host implements Serializable {
     String ami
     String region
-    String name
     String instance_type
-    String keyPair
-    String user
     String vpcSubnetID
     Boolean AssignPublicIP
-    String providerType = 'aws'
     ArrayList<String> security_groups = []
-    ArrayList<String> instance_tags = []
 
     Aws(String ami, String region, String name, String instance_type){
+        super(name, 'aws')
         this.ami = ami
         this.region = region
-        this.name = name
         this.instance_type = instance_type
     }
 
@@ -26,10 +21,6 @@ class Aws implements Serializable{
 
     String getRegion() {
         return region
-    }
-
-    String getName() {
-        return name
     }
 
     String getSecurity_groups() {
@@ -48,30 +39,6 @@ class Aws implements Serializable{
         this.instance_type = size
     }
 
-    ArrayList<String> getinstance_tags() {
-        return instance_tags
-    }
-
-    void setinstance_tags(ArrayList<String> instance_tags) {
-        this.instance_tags = instance_tags
-    }
-
-    String getProviderType() {
-        return providerType
-    }
-
-    void setProviderType(String type) {
-        this.providerType = type
-    }
-
-    String getKeyPair() {
-        return keyPair
-    }
-
-    void setKeyPair(String keyPair) {
-        this.keyPair = keyPair
-    }
-
     String getVpcSubnetID() {
         return vpcSubnetID
     }
@@ -86,13 +53,5 @@ class Aws implements Serializable{
 
     void setAssignPublicIP(Boolean assignPublicIP) {
         AssignPublicIP = assignPublicIP
-    }
-
-    String getUser() {
-        return user
-    }
-
-    void setUser(String user) {
-        this.user = user
     }
 }

--- a/src/org/centos/contra/Infra/Providers/Beaker.groovy
+++ b/src/org/centos/contra/Infra/Providers/Beaker.groovy
@@ -1,7 +1,6 @@
 package org.centos.contra.Infra.Providers
 
-class Beaker implements Serializable{
-    String name
+class Beaker extends Host implements Serializable {
     String distro
     String arch
     String variant
@@ -10,18 +9,12 @@ class Beaker implements Serializable{
     String job_group = ""
     String bkr_data = ""
     String whiteboard = ""
-    String providerType = 'beaker'
-
 
     Beaker(String name, String distro, String arch, String variant) {
-        this.name = name
+        super(name, 'beaker')
         this.distro = distro
         this.arch = arch
         this.variant = variant
-    }
-
-    String getName() {
-        return name
     }
 
     String getDistro() {

--- a/src/org/centos/contra/Infra/Providers/Host.groovy
+++ b/src/org/centos/contra/Infra/Providers/Host.groovy
@@ -1,0 +1,14 @@
+package org.centos.contra.Infra.Providers
+
+class Host implements Serializable {
+    final String name
+    final String providerType
+    String user
+    String keyPair
+    List<String> instance_tags = []
+
+    Host(String name, String providerType) {
+        this.name = name ?: UUID.randomUUID().toString()
+        this.providerType = providerType
+    }
+}

--- a/src/org/centos/contra/Infra/Providers/Openstack.groovy
+++ b/src/org/centos/contra/Infra/Providers/Openstack.groovy
@@ -1,7 +1,6 @@
 package org.centos.contra.Infra.Providers
 
-class Openstack implements Serializable{
-    String name
+class Openstack extends Host implements Serializable{
     String flavor
     String image
     String uuid
@@ -9,30 +8,21 @@ class Openstack implements Serializable{
     String keyPair
     String fipPool
     String network
-    String user
     String userdata
     String volumeSize
     String bootVolume
-    String providerType = 'openstack'
     Boolean terminateVolume
     Boolean bootFromVolume
     Boolean autoIP
     ArrayList<String> nics = new ArrayList<String>()
     ArrayList<String> securityGroups = new ArrayList<String>()
     ArrayList<String> volumes = new ArrayList<String>()
-    ArrayList<String> instance_tags = new ArrayList<String>()
-
-
 
     Openstack(String name, String flavor, String image) {
-        this.name = name
+        super(name, 'openstack')
         this.flavor = flavor
         this.image = image
         this.uuid = UUID.randomUUID().toString().split('-')[0]
-    }
-
-    String getName() {
-        return name
     }
 
     String getNameWithUUID() {
@@ -53,14 +43,6 @@ class Openstack implements Serializable{
 
     void setRegion(String region) {
         this.region = region
-    }
-
-    String getKeyPair() {
-        return keyPair
-    }
-
-    void setKeyPair(String keyPair) {
-        this.keyPair = keyPair
     }
 
     String getFipPool() {
@@ -107,24 +89,8 @@ class Openstack implements Serializable{
         this.terminateVolume = terminateVolume
     }
 
-    String getProviderType() {
-        return providerType
-    }
-
-    void setProviderType(String providerType) {
-        this.providerType = providerType
-    }
-
     String getVolumeSize() {
         return volumeSize
-    }
-
-    String getUser() {
-        return user
-    }
-
-    void setUser(String user) {
-        this.user = user
     }
 
     Boolean getBootFromVolume() {
@@ -175,13 +141,5 @@ class Openstack implements Serializable{
 
     void setVolumes(ArrayList<String> volumes) {
         this.volumes = volumes
-    }
-
-    ArrayList<String> getInstance_tags() {
-        return instance_tags
-    }
-
-    void setInstance_tags(ArrayList<String> instance_tags) {
-        this.instance_tags = instance_tags
     }
 }

--- a/vars/createDslContainers.groovy
+++ b/vars/createDslContainers.groovy
@@ -64,8 +64,7 @@ def call(Map<String, ?> config=[:], Closure body){
             body()
         }
       }
-    } catch (FlowInterruptedException e) {
-        println(e)
+    } catch (FlowInterruptedException) {
         error message:"Provisioning has timed out after ${executionTimeout} ${executionTimeoutUnit.toLowerCase()} - Aborting"
     }
 }

--- a/vars/createDslContainers.groovy
+++ b/vars/createDslContainers.groovy
@@ -64,7 +64,8 @@ def call(Map<String, ?> config=[:], Closure body){
             body()
         }
       }
-    } catch (FlowInterruptedException) {
+    } catch (FlowInterruptedException e) {
+        println(e)
         error message:"Provisioning has timed out after ${executionTimeout} ${executionTimeoutUnit.toLowerCase()} - Aborting"
     }
 }

--- a/vars/destroyInfra.groovy
+++ b/vars/destroyInfra.groovy
@@ -8,11 +8,12 @@ import org.centos.contra.Infra.Utils
  *                                      will be executed from.
  * @return
  */
-def call(Map<String, ?> config=[:]){
+def call(Map<String, ?> config=[:]) {
     def infraUtils = new Utils()
 
-    def configData = readJSON text: env.configJSON
+    config = (env.configJSON ? readJSON(text: env.configJSON) : [:]) << config
 
-    infraUtils.executeInLinchpin("destroy", "--creds-path \"${WORKSPACE}/linchpin/creds\"", config.verbose as Boolean,
-            config.linchpinContainerName)
+    infraUtils.executeInLinchpin('destroy',
+                               "--workspace \"${WORKSPACE}/linchpin\" --creds-path \"${WORKSPACE}/linchpin/creds\"",
+                               config.verbose as Boolean, config.linchpinContainerName)
 }

--- a/vars/executeTests.groovy
+++ b/vars/executeTests.groovy
@@ -13,17 +13,17 @@ import org.centos.contra.Infra.Utils
  *                          will be executed from.
  * @return
  */
-def call(Map<String, String> config = [:]) {
+def call(Map<String, ?> config = [:]) {
 
     def infraUtils = new Utils()
 
-    def configData = env.configJSON ? readJSON(text: env.configJSON) : [:]
+    config = (env.configJSON ? readJSON(text: env.configJSON) : [:]) << config
 
     // If we have a repo defined to checkout the infra configuration playbooks from, let's handle that
-    if (configData.tests?.repo) {
-        String url = configData.tests.repo.url
-        String branch = configData.tests.repo.branch
-        String folder = configData.tests.repo.destination_folder ?: null
+    if (config.tests?.repo) {
+        String url = config.tests.repo.url
+        String branch = config.tests.repo.branch
+        String folder = config.tests.repo.destination_folder ?: null
         if ( folder ){
             dir(folder){
                 git branch: branch, url: url
@@ -34,8 +34,8 @@ def call(Map<String, String> config = [:]) {
     }
 
     // Let's execute our playbooks!
-    if (configData.tests?.playbooks) {
-        configData.tests.playbooks.each { LinkedHashMap playbook ->
+    if (config.tests?.playbooks) {
+        config.tests.playbooks.each { LinkedHashMap playbook ->
             HashMap playbookParams = playbook.vars ?: [:]
             if (config.vars){
                 playbookParams  << (config.vars as HashMap)

--- a/vars/parallelize.groovy
+++ b/vars/parallelize.groovy
@@ -1,0 +1,17 @@
+/**
+ * Parallelizes @param task (Closure) across each Map of arguments in @param argsSets.
+ *
+ * @param argMaps - List of Maps that will be passed as arguments. If the Map has a 'name' field, it will be used to define the name of the branch.
+ * @param task    - Closure that runs the parallelized tasks. Expects a single argument, which is a Map of arguments specified in the argMaps parameter above.
+ */
+def call(List argMaps, Closure task) {
+    Map argBoundTasks = [:]
+    Closure bindArgsToTask = { Map args -> { -> task(args) } }
+
+    argMaps.eachWithIndex {
+        Map args, Integer index ->
+        argBoundTasks[args.name ?: index] = bindArgsToTask(args)
+    }
+
+    parallel(argBoundTasks)
+}

--- a/vars/parallelize.txt
+++ b/vars/parallelize.txt
@@ -1,0 +1,14 @@
+<p>The parallelize variable handles the abstract tasks of turning a list of argument maps and a Closure that takes those maps and executes each of those in parallel threads using the Jenkins parallel step. The parallel steps are named after the <code>name</code> key of the provided map, or the index if a name is not provided.</p>
+
+<h1 id="warning">Warning</h1>
+
+<p>Usage of this variable can seriously mess up your pipeline if you are not viligant in ensuring that you have protected critical sections and have prevented deadlock scenarios. Many steps, suchs as the <code>podTemplate</code> step provided by the Kubernetes plugin, are incompatible with this step since parallel calls overwrite the Jenkins configuration, creating deadlock. It is recommended that this variable is only accessed through the <code>parallelizeInfra</code> variable.</p>
+
+<h1 id="examples">Examples:</h1>
+
+<h2 id="basic-usage">Basic usage:</h2>
+<pre><code>parallel([[name: 'cluster1', arch: 'x86_64'], [name:'cluster2', arch: 'ppc64le']]) {
+    Map args ->
+    println(args)
+}
+</code></pre>

--- a/vars/parallelizeInfra.groovy
+++ b/vars/parallelizeInfra.groovy
@@ -1,0 +1,30 @@
+/**
+ * This function attempts to consume an HDSL config and run the test contents in parallel.
+ *
+ * @param config - A parsed hdsl configuration.
+ * @param test   - Closure that is the body of the
+ */
+def call(Map config, Closure test) {
+    // Support single infra use case
+    if (config.infra && config.infra instanceof Map) {
+        return test(config)
+    }
+
+    // Clone each infra into a separate config and run in parallel
+    List configs = []
+    for (infra in config.infra) {
+        Map singleInfraConfig = [:]
+        singleInfraConfig << config
+        singleInfraConfig.infra = infra
+        singleInfraConfig.name = infra.name
+        configs.push(singleInfraConfig)
+    }
+
+    // Run the new single infra configs in parallel and in separate hdsl pods
+    parallelize(configs) {
+        singleInfraConfig ->
+        node(hdslPodName) {
+            test(singleInfraConfig)
+        }
+    }
+}

--- a/vars/parallelizeInfra.txt
+++ b/vars/parallelizeInfra.txt
@@ -1,0 +1,23 @@
+<p>The parallelizeInfra variable handles turning an HDSL yaml file with a list of infras into a parallelized execution single infra HDSL configs. Because HDSL expects a single infra specification, the split configs must be passed to future HDSL steps through the <code>config</code> variable.</p>
+
+<h1 id="recommendations">Recommendations</h1>
+
+<p>Usage of this variable can seriously mess up your pipeline if you are not viligant in ensuring that you have protected critical sections and have prevented deadlock scenarios. Many steps, suchs as the <code>podTemplate</code> step provided by the Kubernetes plugin, are incompatible with this step since parallel calls overwrite the Jenkins configuration, creating deadlock.</p>
+
+<p>It is recommended that you use this variable to restructure your HDSL file to consume the configuration yaml and pass it along to future steps as shown below. The names of the parallel steps will default to the value found in the <code>name</code> key of the infra if one is provided, otherwise the index will be used as described in the <code>parallelize</code> step.</p>
+
+<h1 id="examples">Examples:</h1>
+
+<h2 id="basic-usage">Basic usage:</h2>
+<pre><code>stage("Parse Configuration") {
+        config = parseConfig(filename:'job.yml') << config
+    }
+
+    parallelizeInfra(config) {
+        singleInfraConfig ->
+        stage("Deploy Infra") {
+            deployInfra(singleInfraConfig)
+        }
+    }
+}
+</code></pre>

--- a/vars/parseConfig.groovy
+++ b/vars/parseConfig.groovy
@@ -10,11 +10,13 @@ import groovy.json.JsonBuilder
  */
 
 
-def call(Map <String,?> config=[:]){
+Map call(Map <String,?> config=[:]){
 
     String configuration_file = config.filename ?: 'contra.yml'
 
     def yaml = readYaml file: "${WORKSPACE}/${configuration_file}" as String
 
     env.configJSON = new JsonBuilder(yaml)
+
+    readJSON(text:env.configJSON)
 }

--- a/vars/report.groovy
+++ b/vars/report.groovy
@@ -1,18 +1,18 @@
 def call(Map<String, ?> config = [:]) {
     String reportingType = config.reportingType ?: 'email'
 
-    Map<String, String> configData = readJSON text: env.configJSON
+    config = readJSON(text: env.configJSON) << config
 
     if (reportingType == 'email'){
         ArrayList recipientEmails = []
         ArrayList ccEmails = []
         ArrayList bccEmails = []
 
-        if ( configData.recipientEmail ) { combineEmailAddresses(recipientEmails, configData.recepientEmail) }
+        if ( config.recipientEmail ) { combineEmailAddresses(recipientEmails, config.recepientEmail) }
         if ( config.recipientEmail ){ combineEmailAddresses(recipientEmails, config.recipientEmail) }
-        if ( configData.ccEmail ) { combineEmailAddresses(ccEmails, configData.ccEmail) }
+        if ( config.ccEmail ) { combineEmailAddresses(ccEmails, config.ccEmail) }
         if ( config.ccEmail ){ combineEmailAddresses(ccEmails, config.ccEmail) }
-        if ( configData.bccEmail ) { combineEmailAddresses(bccEmails, configData.bccEmail) }
+        if ( config.bccEmail ) { combineEmailAddresses(bccEmails, config.bccEmail) }
         if ( config.bccEmail ){ combineEmailAddresses(bccEmails, config.bccEmail) }
 
         // subject: JOB NAME - BUILD - RESULT

--- a/vars/saveArtifacts.groovy
+++ b/vars/saveArtifacts.groovy
@@ -17,7 +17,7 @@
  */
 def call(Map <String, ?> config=[:]) {
 
-    def configData = readJSON text: env.configJSON
+    config = readJSON(text: env.configJSON) << config
 
     ArrayList filesToSave = []
     ArrayList filesToExclude = []
@@ -33,16 +33,16 @@ def call(Map <String, ?> config=[:]) {
         // If we reach a NullPointerException, we log it, and move forward, as there may be
         // parameters passed in via the Jenkinsfile call.
 
-        configData
+        config
         key="configData"
-        configData.get('results')
+        config.get('results')
         key="results"
-        configData.results.get('outputTypes')
+        config.results.get('outputTypes')
         key="outputTypes"
-        configData.results.outputTypes.get('artifacts')
+        config.results.outputTypes.get('artifacts')
         key="artifacts"
 
-        Map artifacts = configData.results.outputTypes.artifacts
+        Map artifacts = config.results.outputTypes.artifacts
         filesToSave = artifacts.filesToSave ? formatFileSet(artifacts.filesToSave) : filesToSave
         filesToExclude = artifacts.filesToExclude ? formatFileSet(artifacts.filesToExclude) : filesToExclude
 
@@ -82,7 +82,7 @@ def call(Map <String, ?> config=[:]) {
         }
 
         archiveArtifacts(command)
-        
+
     } else {
         println("No files specified to archive, skipping artifact archiving.")
     }

--- a/vars/withHdslPod.groovy
+++ b/vars/withHdslPod.groovy
@@ -19,9 +19,10 @@ def call(Map<String,String> config=[:], Closure body){
     config.source = config.source ?: defaultImageSource
 
     String openshiftServiceAccount = config.openshift_service_account ?: openshiftServiceAccount
+    String openshiftNamespace = config.openshift_namespace ?: infraUtils.getOpenshiftNamespace()
 
     // Linchpin Container
-    config.linchpin_container_name = config.linchpin_container_name ?: linchpinContainerName
+    config.linchpinContainerName = config.linchpinContainerName ?: linchpinContainerName
 
     /*
         If there's a value for config.<container_image_name>, we use that.
@@ -52,7 +53,7 @@ def call(Map<String,String> config=[:], Closure body){
                     linchpinDockerhubTag
 
     // Ansible Container
-    config.ansible_container_name = config.ansible_container_name ?: ansibleContainerName
+    config.ansibleContainerName = config.ansibleContainerName ?: ansibleContainerName
     config.ansible_image_name = config.ansible_image_name ?:
             config.source == 'openshift' ?
                     ansibleImageName :
@@ -78,13 +79,13 @@ def call(Map<String,String> config=[:], Closure body){
             cloud: 'openshift',
             serviceAccount: openshiftServiceAccount,
             idleMinutes: 0,
-            namespace: infraUtils.getOpenshiftNamespace(),
+            namespace: openshiftNamespace,
             containers:[
                     // This adds the custom slave container to the pod. Must be first with name 'jnlp'
                     containerTemplate(
                             name: config.jnlp_container_name,
                             image: config.source == 'openshift' ?
-                                    infraUtils.getOpenShiftImageUrl(config.jnlp_image_name, config.jnlp_tag) :
+                                    infraUtils.getOpenShiftImageUrl(openshiftNamespace, config.jnlp_image_name, config.jnlp_tag) :
                                     infraUtils.getDockerHubImageURL(config.jnlp_image_name, config.jnlp_tag),
                             ttyEnabled: false,
                             alwaysPullImage: true,
@@ -94,9 +95,9 @@ def call(Map<String,String> config=[:], Closure body){
                     ),
                     // This adds the ansible-executor container to the pod.
                     containerTemplate(
-                            name: config.ansible_container_name,
+                            name: config.ansibleContainerName,
                             image: config.source == 'openshift' ?
-                                    infraUtils.getOpenShiftImageUrl(config.ansible_image_name, config.ansible_tag) :
+                                    infraUtils.getOpenShiftImageUrl(openshiftNamespace, config.ansible_image_name, config.ansible_tag) :
                                     infraUtils.getDockerHubImageURL(config.ansible_image_name, config.ansible_tag),
                             ttyEnabled: true,
                             alwaysPullImage: true,
@@ -105,9 +106,9 @@ def call(Map<String,String> config=[:], Closure body){
                     ),
                     // This adds the linchpin-executor container to the pod.
                     containerTemplate(
-                            name: config.linchpin_container_name,
+                            name: config.linchpinContainerName,
                             image: config.source == 'openshift' ?
-                                    infraUtils.getOpenShiftImageUrl(config.linchpin_image_name, config.linchpin_tag) :
+                                    infraUtils.getOpenShiftImageUrl(openshiftNamespace, config.linchpin_image_name, config.linchpin_tag) :
                                     infraUtils.getDockerHubImageURL(config.linchpin_image_name, config.linchpin_tag),
                             ttyEnabled: true,
                             alwaysPullImage: true,
@@ -119,4 +120,3 @@ def call(Map<String,String> config=[:], Closure body){
        body()
     }
 }
-

--- a/vars/withPod.groovy
+++ b/vars/withPod.groovy
@@ -13,7 +13,7 @@ def call(Map config=[:], Closure body) {
     env.userPodName = config.podName ?: "pod-${UUID.randomUUID()}"
 
     String openshiftServiceAccount = config.openshift_service_account ?: openshiftServiceAccount
-    openshiftNamespace = config.openshift_namespace ?: infraUtils.getOpenshiftNamespace()
+    String openshiftNamespace = config.openshift_namespace ?: infraUtils.getOpenshiftNamespace()
 
     config.jnlp_image_name = config.jnlp_image_name ?: jnlpImageName
     config.jnlp_tag = config.jnlp_tag ?:

--- a/vars/withPod.groovy
+++ b/vars/withPod.groovy
@@ -7,14 +7,13 @@ import static org.centos.contra.Infra.Defaults.*
  * @param body
  * @return
  */
-def call(Map config=[:], Closure body){
-
+def call(Map config=[:], Closure body) {
     def infraUtils = new Utils()
 
     env.userPodName = config.podName ?: "pod-${UUID.randomUUID()}"
 
-    config.openshift_service_account = config.openshift_service_account ?: openshiftServiceAccount
-    config.openshift_namespace = config.openshift_namespace ?: infraUtils.getOpenshiftNamespace()
+    String openshiftServiceAccount = config.openshift_service_account ?: openshiftServiceAccount
+    openshiftNamespace = config.openshift_namespace ?: infraUtils.getOpenshiftNamespace()
 
     config.jnlp_image_name = config.jnlp_image_name ?: jnlpImageName
     config.jnlp_tag = config.jnlp_tag ?:
@@ -23,7 +22,7 @@ def call(Map config=[:], Closure body){
                     jnlpDockerhubTag
 
     String jnlpImageURL = defaultImageSource == 'openshift' ?
-            infraUtils.getOpenShiftImageUrl(config.jnlp_image_name as String, config.jnlp_tag as String) :
+            infraUtils.getOpenShiftImageUrl(openshiftNamespace, config.jnlp_image_name as String, config.jnlp_tag as String) :
             infraUtils.getDockerHubImageURL(config.jnlp_iamge_name as String, config.jnlp_tag as String)
 
     // Create the containers array, and prepopulate it with our JNLP slave
@@ -52,7 +51,7 @@ def call(Map config=[:], Closure body){
                     containerTemplate(
                             name: container.containerName,
                             image: container.source == 'openshift' ?
-                                    infraUtils.getOpenShiftImageUrl(container.image, container.tag) :
+                                    infraUtils.getOpenShiftImageUrl(openshiftNamespace, container.image, container.tag) :
                                     infraUtils.getDockerHubImageURL(container.image, container.tag),
                             ttyEnabled: container.ttyEnabled in ['true', true],
                             alwasyPullImage: true,


### PR DESCRIPTION
This is large change set work in progress. I am creating this PR to get feedback so that I can iterate on this until it is production ready.

An example of a compatible Jenkinsfile is found [here](https://github.com/jaypoulz/multiarch-ci-test-template/blob/dev-v2.0.0/Jenkinsfile).

TODO list:
- [x] Run the tests and ensure update tests for compatibility
- [x] Clean up the beaker authentication code to ensure all of the extra configuration is purely optional
- [x] Reformat the files where my updates do not match the original indentation level
- [x] Ensure the HDSL example at [hdsl_sample](https://github.com/robnester-rh/hdsl_sample) still functions out of the box or at least with minimal changes
- [x] Clean up the commits themselves into discrete units of work
- [x] Finalize documentation for new steps and functions
- [x] Implement review feedback from Rob & Charlotte
---
# Functional / API Level Changes
* The biggest change by far is that since configuration needs to be parallelized and tracked in different threads, we no longer serialize it to a file and re-read it every time we need it. Instead, similar to how ansible does variable precedence, we parse the configuration variables and fold the configuration overrides in the Jenkinsfile into that base configuration with higher precedence. For parallel builds we restructure this object with a single "infra" object for each "infra", and we pass this new configuration to each executing thread.
**Update**
I reworked the way I was handling configuration so that I re-parse from the serialized file and re-overwrite it with the passed configuration for each individualized step that uses it. This allows us to maintain current functionality will allowing use to override the config for parallelized use cases without having to protect the configuration file for critical sections.
* There was some duplication in the structuring of the Host/Provider based objects. I have consolidated the shared attributes into a base class since the beaker provider was missing them.