### PR TITLE
FIX catch in createDslContainers

### DIFF
--- a/src/org/centos/contra/Infra/Defaults.groovy
+++ b/src/org/centos/contra/Infra/Defaults.groovy
@@ -40,4 +40,5 @@ class Defaults {
 
     // The default timeout in MINUTES
     public static final int executionTimeout = 30
+    public static final String executionTimeoutUnit = 'MINUTES'
 }

--- a/vars/createDslContainers.groovy
+++ b/vars/createDslContainers.groovy
@@ -1,4 +1,5 @@
 import static org.centos.contra.Infra.Defaults.*
+import org.jenkinsci.plugins.workflow.steps.FlowInterruptedException
 
 /**
  * A method which executes the podTemplate step to create the required ansible-executor and linchpin-executor containers defined.
@@ -26,7 +27,7 @@ def call(Map<String, ?> config=[:], Closure body){
     String ansibleContainerName = config.ansibleContainerName ?: 'ansible-executor'
 
     try {
-      timeout(time: executionTimeout, unit: 'MINUTES') {
+      timeout(time: executionTimeout, unit: executionTimeoutUnit) {
 
         podTemplate(name: podName,
                 label: podName,
@@ -63,7 +64,7 @@ def call(Map<String, ?> config=[:], Closure body){
             body()
         }
       }
-    } catch (Exception e) {
-      echo "Timeout reached - Aborting"
+    } catch (FlowInterruptedException) {
+        error message:"Provisioning has timed out after ${executionTimeout} ${executionTimeoutUnit.toLowerCase()} - Aborting"
     }
 }


### PR DESCRIPTION
Fixed the catch in the createDslContainers var so that it only catches a
FlowInterruptedException caused by the enclosing timeout. Any exceptions
contained within the body should be handled seperately now.

Additionaly, implemented the error step so that the job would correctly
show as failed, instead of successful due to catching the exception.

This resolves #87 